### PR TITLE
ci: rolling-release build + dispatch to platform repo

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -1,0 +1,113 @@
+# Ziel: NEUE Workflow-Datei in eegfaktura/eegfaktura-billing (existiert dort
+# bisher nicht). Analog zu eegfaktura-filestore/rolling-release.yml.
+#
+# Vorbedingung: Repo-Secret `PLATFORM_DEPLOY_PAT` muss gesetzt sein
+# (Classic PAT mit Scope `repo` auf vfeeg-development/eegfaktura-platform).
+
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - v*
+
+env:
+  REGISTRY: "ghcr.io"
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=short,prefix=sha-
+          labels: |
+            org.opencontainers.image.title="eegfaktura-billing"
+            org.opencontainers.image.description="EEG Faktura billing service - PDF-Abrechnungserzeugung"
+            org.opencontainers.image.source=${{ github.event.repository.html_url || '' }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url || '' }}
+            org.opencontainers.image.version=${{ github.sha || '' }}
+            org.opencontainers.image.revision=${{ github.sha || '' }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp || '' }}
+            org.opencontainers.image.authors="eegfaktura@vfeeg.org"
+            org.opencontainers.image.vendor="Verein zur Förderung von Erneuerbaren Energiegemeinschaften"
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id || '' }}
+            org.opencontainers.image.ref.name=${{ github.ref || '' }}
+            org.opencontainers.image.ref.branch=${{ github.ref_type == 'branch' && github.ref || '' }}
+            org.opencontainers.image.ref.tag=${{ github.ref_type == 'tag' && github.ref || '' }}
+            org.opencontainers.image.ref.sha=${{ github.sha || '' }}
+            org.opencontainers.image.repository=${{ github.repository || '' }}
+            org.opencontainers.image.repository.url=${{ github.event.repository.html_url || '' }}
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags || 'latest' }}
+          labels: ${{ steps.meta.outputs.labels || '' }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  dispatch-deploy:
+    needs: build-and-push-image
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deploy in platform repo
+        env:
+          GH_TOKEN: ${{ secrets.PLATFORM_DEPLOY_PAT }}
+        run: |
+          PAYLOAD=$(cat <<EOF
+          {
+            "event_type": "deploy-billing",
+            "client_payload": {
+              "image_tag": "latest",
+              "source_sha": "${GITHUB_SHA}",
+              "source_repo": "${GITHUB_REPOSITORY}",
+              "source_ref": "${GITHUB_REF}"
+            }
+          }
+          EOF
+          )
+          echo "$PAYLOAD" | gh api repos/vfeeg-development/eegfaktura-platform/dispatches --input -
+          echo "Dispatched deploy-billing for sha=${GITHUB_SHA:0:8}"


### PR DESCRIPTION
## Summary

Initial GHA workflow for `eegfaktura-billing`:

- Build + push image to `ghcr.io/eegfaktura/eegfaktura-billing` on push to `master`.
- Tags: `:latest` (default branch), `:master` (branch name), `:sha-<short>`, plus semver on `v*` tags.
- OCI labels with source-link and `AGPL-3.0` license — auto-fulfills AGPL §13 source link for any deployment using this image.
- Signed `attest-build-provenance`.
- `dispatch-deploy` job at end: notifies `vfeeg-development/eegfaktura-platform` via `repository_dispatch` (event type `deploy-billing`), where `.github/workflows/deploy-on-dispatch.yml` triggers a `kubectl rollout restart` against the dev cluster `eegf-dev` (STACKIT eu02).

Concept doc: https://github.com/vfeeg-development/eegfaktura-platform/blob/main/docs/build-pipeline.md

## Prerequisites

- Repo secret `PLATFORM_DEPLOY_PAT` set (fine-grained PAT, `Contents: write` only on `vfeeg-development/eegfaktura-platform`). Already configured.

## Test plan

- [ ] Merge to `master` → workflow runs → image pushed to `ghcr.io/eegfaktura/eegfaktura-billing:latest`
- [ ] `dispatch-deploy` job logs `Dispatched deploy-billing for sha=...`
- [ ] In platform repo, `deploy-on-dispatch.yml` runs and the billing Pod in NS `eegfaktura` restarts within ~2 min