### PR TITLE
fix(docker): multi-stage Build with version-glob runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
+# Multi-Stage Build: Maven-Builder + Temurin-Runtime
+# Vermeidet das Pre-Build-JAR-Coupling — das target/-Verzeichnis ist .gitignored,
+# also kann ein Source-Build-Workflow nicht direkt das alte single-stage
+# `COPY target/...jar` nutzen.
+
+FROM maven:3-eclipse-temurin-21 AS builder
+WORKDIR /build
+
+# Dependencies separat cachen (langsamer initial-build, schneller bei Source-Changes)
+COPY pom.xml .
+RUN mvn -B -ntp dependency:go-offline -DskipTests
+
+COPY src ./src
+RUN mvn -B -ntp clean package -DskipTests
+
 FROM eclipse-temurin:21
-COPY target/eegfaktura-billing-0.1.22.jar /tmp
-WORKDIR /tmp
-ENTRYPOINT ["java","-jar","eegfaktura-billing-0.1.22.jar"]
+# Version-Glob: passt zu jedem `eegfaktura-billing-*.jar`, robust gegen pom.xml-Bumps.
+COPY --from=builder /build/target/eegfaktura-billing-*.jar /opt/app/eegfaktura-billing.jar
+WORKDIR /opt/app
+ENTRYPOINT ["java","-jar","/opt/app/eegfaktura-billing.jar"]


### PR DESCRIPTION
Single-stage Dockerfile expected a pre-built JAR (`target/eegfaktura-billing-0.1.22.jar`) which doesn't exist in a fresh checkout (Maven `target/` is gitignored). Replaces it with a multi-stage Maven builder + Temurin runtime. Version-glob in COPY makes the runtime stage independent of pom version bumps.

Companion fix for the [PR #17 rolling-release workflow](https://github.com/eegfaktura/eegfaktura-billing/pull/17) which failed on the JAR-not-found error.