### PR TITLE
SMTP Header changes

### DIFF
--- a/src/main/java/org/vfeeg/eegfaktura/billing/service/EmailService.java
+++ b/src/main/java/org/vfeeg/eegfaktura/billing/service/EmailService.java
@@ -34,8 +34,9 @@ public class EmailService {
         if (!StringHelper.isNullOrEmptyString(cc)) {
             String[] ccArray = cc.split(";");
             helper.setCc(ccArray);
-            helper.setReplyTo(ccArray[0]);
-            message.setHeader("return-path", ccArray[0]);
+            // Remove replyTo and return Path header because it might increase SPAM score
+            // helper.setReplyTo(ccArray[0]);
+            // message.setHeader("return-path", ccArray[0]);
         }
         helper.setSubject(subject);
         helper.setText(htmlBody, true);


### PR DESCRIPTION
Remove of **reply-to** and **return-path** header due to spam classification if reply-to domain does not match sender domain and return-path is only set on mail server level.