### PR TITLE
ci: preview deployments for unmerged branches (ADR-0007)

### DIFF
--- a/.github/workflows/preview-reset.yml
+++ b/.github/workflows/preview-reset.yml
@@ -1,0 +1,20 @@
+# ADR-0007: Auto-Reset der Dev-Zone, wenn ein preview/**-Branch geloescht wird.
+# Feuert den bestehenden deploy-billing-Dispatch OHNE Payload -> Receiver macht latest
+# (rollout restart zieht :latest = main-Stand).
+name: Reset dev preview on branch delete
+
+on:
+  delete:
+
+jobs:
+  reset-preview:
+    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'preview/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch latest-reset to platform
+        env:
+          GH_TOKEN: ${{ secrets.PLATFORM_DEPLOY_PAT }}
+        run: |
+          gh api repos/vfeeg-development/eegfaktura-platform/dispatches \
+            -f event_type=deploy-billing
+          echo "Reset dev to :latest for billing (deleted ${{ github.event.ref }})"

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - master
       - main
+      - 'preview/**'
     tags:
       - v*
 
@@ -118,3 +119,30 @@ jobs:
           )
           echo "$PAYLOAD" | gh api repos/vfeeg-development/eegfaktura-platform/dispatches --input -
           echo "Dispatched deploy-billing for sha=${GITHUB_SHA:0:8}"
+
+  # Preview-Deploy (ADR-0007): Push auf preview/** -> pinned Deploy des sha-Builds
+  # in die Dev-Zone, ohne main/Release anzufassen. Nur auf preview/**-Branches.
+  dispatch-preview-deploy:
+    needs: build-and-push-image
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/preview/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger pinned preview deploy in platform repo
+        env:
+          GH_TOKEN: ${{ secrets.PLATFORM_DEPLOY_PAT }}
+        run: |
+          PAYLOAD=$(cat <<EOF
+          {
+            "event_type": "deploy-billing",
+            "client_payload": {
+              "mode": "pinned",
+              "image_tag": "sha-${GITHUB_SHA:0:7}",
+              "source_sha": "${GITHUB_SHA}",
+              "source_repo": "${GITHUB_REPOSITORY}",
+              "source_ref": "${GITHUB_REF}"
+            }
+          }
+          EOF
+          )
+          echo "$PAYLOAD" | gh api repos/vfeeg-development/eegfaktura-platform/dispatches --input -
+          echo "Dispatched pinned preview deploy-billing for sha-${GITHUB_SHA:0:7}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Changed
+- CI: Preview-Deployments (ADR-0007) — Push auf `preview/**` baut+deployt on-demand in die Dev-Zone (sha-pinned, kein `:latest`), Auto-Reset bei Branch-Delete.
+
 ## [1.0.1] – 2026-06-30
 
 ### Changed


### PR DESCRIPTION
## Was

Rollout von **ADR-0007** (Preview-Deployments) in diesem Service-Repo.

- `preview/**` als Push-Trigger im Build-Workflow → baut+pusht `sha-<short>` (kein `:latest`/`:v*`, via `is_default_branch`-Gating).
- Neuer Job **`dispatch-preview-deploy`** (nur auf `refs/heads/preview/`): feuert den `deploy-<service>`-Dispatch mit `client_payload {mode: pinned, image_tag: sha-<7>}` → Dev-Zone übernimmt den Branch-Build **in-place**, ohne `main` anzufassen.
- Neuer Mini-Workflow **`preview-reset.yml`** (`on: delete`): löscht du den `preview/`-Branch, wird die Dev-Zone automatisch auf `:latest` (main-Stand) zurückgesetzt.

Der bestehende `dispatch-deploy` (main→latest) bleibt unangetastet. Setzt die Platform-Receiver-Änderung voraus (vfeeg-development/eegfaktura-platform#39: `deploy-on-dispatch.yml` liest `mode`/`image_tag` aus dem Payload).

Entwickler-Ablauf: `git push origin HEAD:preview/<name>` → in Dev testen → Branch löschen (Reset) → dann mergen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
