### PR TITLE
feat(mail): Empfänger normalisieren+validieren vor Versand, zuordenbares Fehler-Protokoll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Fixed
+- Mail send no longer hands raw recipient strings to the mail parser ("Illegal address",
+  observed in prod for addresses with leading/trailing whitespace): to/cc are normalized per
+  `;`-separated part (outer whitespace incl. NBSP stripped) and validated against the shared
+  suite-wide address rule before the MimeMessage is built; the normalized values are what
+  actually gets sent. Invalid parts are reported instead of failing the whole message —
+  no valid recipient at all remains an error.
+
+### Changed
+- Billing run send protocol: a failed send now names the member (participant number + name)
+  next to the address — a blank/garbage address used to produce an unattributable
+  "  FEHLER" entry.
+
 ## [1.0.0] – 2026-06-28
 
 Part of the unified source-build cutover of the eegfaktura suite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ this changelog highlights the changes relevant for overview and operations.
 ### Changed
 - Billing run send protocol: a failed send now names the member (participant number + name)
   next to the address — a blank/garbage address used to produce an unattributable
-  "  FEHLER" entry.
+  "  FEHLER" entry. Rejected address parts on an otherwise delivered mail (e.g. an invalid
+  issuer cc) are reported as a warning on the OK line, NOT as FEHLER — flagging a delivered
+  invoice as failed would invite manual re-sends and duplicate invoices.
 
 ## [1.0.0] – 2026-06-28
 

--- a/src/main/java/org/vfeeg/eegfaktura/billing/service/BillingDocumentMailService.java
+++ b/src/main/java/org/vfeeg/eegfaktura/billing/service/BillingDocumentMailService.java
@@ -26,6 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -85,7 +86,7 @@ public class BillingDocumentMailService {
         return defaultTemplate;
     }
 
-    private void createAndSendMail(BillingDocument billingDocument) {
+    private List<String> createAndSendMail(BillingDocument billingDocument) {
 
         try {
             List<BillingDocumentFile> billingDocumentFiles = billingDocumentFileRepository.findByBillingDocumentId(
@@ -125,14 +126,12 @@ public class BillingDocumentMailService {
                     billingDocument.getBillingDocumentType()) + " " +billingDocument.getClearingPeriodIdentifier();
             String htmlBody = FreeMarkerTemplateUtils.processTemplateIntoString(freemarkerTemplate, templateModel);
 
-            var rejected = emailService.sendEmail(
+            // Rejected parts are NOT a failed send — the mail went out to
+            // the valid recipients. Reporting them as FEHLER would trigger
+            // manual re-sends (duplicate invoices); they surface as a
+            // warning in the run protocol instead.
+            return emailService.sendEmail(
                     from,to, cc, subject, htmlBody, attachments);
-            if (!rejected.isEmpty()) {
-                // Delivery to the valid recipients already happened —
-                // surface the invalid parts so the run protocol shows them.
-                throw new RuntimeException("ungültige Empfänger nicht zugestellt: "
-                        + String.join(";", rejected));
-            }
         } catch (Exception e) {
             throw new RuntimeException("Mailversand ("+billingDocument.getRecipientEmail()+") fehlgeschlagen aufgrund: "+e.getMessage(), e);
         }
@@ -162,16 +161,23 @@ public class BillingDocumentMailService {
                 .append(": ");
         for(BillingDocument billingDocument : billingDocuments) {
             try {
-                createAndSendMail(billingDocument);
-                sendProtocolStringBuilder.append(billingDocument.getRecipientEmail()).append(" OK,");
+                var rejected = createAndSendMail(billingDocument);
+                sendProtocolStringBuilder.append(billingDocument.getRecipientEmail()).append(" OK");
+                if (!rejected.isEmpty()) {
+                    // Delivered, but some address parts (e.g. an invalid cc)
+                    // were dropped — warn without flagging the send as failed.
+                    sendProtocolStringBuilder.append(" (nicht zugestellt an ungültige Adresse: ")
+                            .append(String.join(";", rejected)).append(")");
+                }
+                sendProtocolStringBuilder.append(",");
             } catch (Exception e) {
                 log.error("Failed to send mail: {}", e.getMessage(), e);
                 // Identify the member behind the failed address — with a
                 // blank/garbage address the bare e-mail ("  FEHLER") is
                 // impossible to attribute for the tenant admin.
                 sendProtocolStringBuilder.append(billingDocument.getRecipientEmail())
-                        .append(" (MitgliedsNr ").append(billingDocument.getRecipientParticipantNumber())
-                        .append(", ").append(billingDocument.getRecipientName()).append(")")
+                        .append(" (MitgliedsNr ").append(Objects.toString(billingDocument.getRecipientParticipantNumber(), "-"))
+                        .append(", ").append(Objects.toString(billingDocument.getRecipientName(), "-")).append(")")
                         .append(" FEHLER,");
             }
         }

--- a/src/main/java/org/vfeeg/eegfaktura/billing/service/BillingDocumentMailService.java
+++ b/src/main/java/org/vfeeg/eegfaktura/billing/service/BillingDocumentMailService.java
@@ -125,8 +125,14 @@ public class BillingDocumentMailService {
                     billingDocument.getBillingDocumentType()) + " " +billingDocument.getClearingPeriodIdentifier();
             String htmlBody = FreeMarkerTemplateUtils.processTemplateIntoString(freemarkerTemplate, templateModel);
 
-            emailService.sendEmail(
+            var rejected = emailService.sendEmail(
                     from,to, cc, subject, htmlBody, attachments);
+            if (!rejected.isEmpty()) {
+                // Delivery to the valid recipients already happened —
+                // surface the invalid parts so the run protocol shows them.
+                throw new RuntimeException("ungültige Empfänger nicht zugestellt: "
+                        + String.join(";", rejected));
+            }
         } catch (Exception e) {
             throw new RuntimeException("Mailversand ("+billingDocument.getRecipientEmail()+") fehlgeschlagen aufgrund: "+e.getMessage(), e);
         }
@@ -160,7 +166,13 @@ public class BillingDocumentMailService {
                 sendProtocolStringBuilder.append(billingDocument.getRecipientEmail()).append(" OK,");
             } catch (Exception e) {
                 log.error("Failed to send mail: {}", e.getMessage(), e);
-                sendProtocolStringBuilder.append(billingDocument.getRecipientEmail()).append(" FEHLER,");
+                // Identify the member behind the failed address — with a
+                // blank/garbage address the bare e-mail ("  FEHLER") is
+                // impossible to attribute for the tenant admin.
+                sendProtocolStringBuilder.append(billingDocument.getRecipientEmail())
+                        .append(" (MitgliedsNr ").append(billingDocument.getRecipientParticipantNumber())
+                        .append(", ").append(billingDocument.getRecipientName()).append(")")
+                        .append(" FEHLER,");
             }
         }
         billingRun.setMailStatus("SENT");

--- a/src/main/java/org/vfeeg/eegfaktura/billing/service/EmailService.java
+++ b/src/main/java/org/vfeeg/eegfaktura/billing/service/EmailService.java
@@ -4,12 +4,14 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.util.ByteArrayDataSource;
 import jakarta.transaction.Transactional;
-import org.hibernate.validator.internal.util.StringHelper;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MimeTypeUtils;
+import org.vfeeg.eegfaktura.billing.util.EmailAddressUtil;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -23,17 +25,38 @@ public class EmailService {
         this.emailSender = emailSender;
     }
 
-    public void sendEmail(
+    /**
+     * Sends the mail to all valid recipients and returns the rejected
+     * (invalid) address parts so the caller can surface them — instead
+     * of handing raw strings to the mail parser ("Illegal address").
+     * Addresses are normalized per ';'-part (unicode strip incl. NBSP)
+     * and validated against the shared suite-wide rule; the normalized
+     * values are what actually gets sent. No valid "to" at all is an
+     * error.
+     */
+    public List<String> sendEmail(
             String from , String to, String cc, String subject, String htmlBody,
             Map<String, byte[]> attachments) throws MessagingException {
+
+        List<String> rejected = new ArrayList<>();
+
+        List<String> toParts = EmailAddressUtil.normalize(to);
+        List<String> validTo = toParts.stream().filter(EmailAddressUtil::isValid).toList();
+        rejected.addAll(toParts.stream().filter(p -> !EmailAddressUtil.isValid(p)).toList());
+        if (validTo.isEmpty()) {
+            throw new MessagingException("invalid email (" + to + ")");
+        }
+
+        List<String> ccParts = EmailAddressUtil.normalize(cc);
+        List<String> validCc = ccParts.stream().filter(EmailAddressUtil::isValid).toList();
+        rejected.addAll(ccParts.stream().filter(p -> !EmailAddressUtil.isValid(p)).toList());
 
         MimeMessage message = emailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
         helper.setFrom(from);
-        helper.setTo(to.split(";"));
-        if (!StringHelper.isNullOrEmptyString(cc)) {
-            String[] ccArray = cc.split(";");
-            helper.setCc(ccArray);
+        helper.setTo(validTo.toArray(new String[0]));
+        if (!validCc.isEmpty()) {
+            helper.setCc(validCc.toArray(new String[0]));
             // Remove replyTo and return Path header because it might increase SPAM score
             // helper.setReplyTo(ccArray[0]);
             // message.setHeader("return-path", ccArray[0]);
@@ -51,5 +74,6 @@ public class EmailService {
         }
         emailSender.send(message);
 
+        return rejected;
     }
 }

--- a/src/main/java/org/vfeeg/eegfaktura/billing/util/EmailAddressUtil.java
+++ b/src/main/java/org/vfeeg/eegfaktura/billing/util/EmailAddressUtil.java
@@ -1,0 +1,40 @@
+package org.vfeeg.eegfaktura.billing.util;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Shared e-mail address rule of the eegfaktura suite (backend, eda-xp,
+ * billing, web): per ';'-separated part — outer unicode whitespace
+ * (incl. NBSP) stripped, ASCII local part, TLD of at least two letters,
+ * no TLD allowlist.
+ */
+public final class EmailAddressUtil {
+
+    private static final Pattern ADDRESS_PART = Pattern.compile(
+            "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$", Pattern.CASE_INSENSITIVE);
+
+    private EmailAddressUtil() {
+    }
+
+    /**
+     * Splits a ';'-separated address list, strips outer whitespace per
+     * part and drops empty parts. NBSP (U+00A0, typical Excel/copy-paste
+     * artifact) is mapped to a space first — neither String#trim nor
+     * String#strip treats it as whitespace ({@code Character.isWhitespace}
+     * excludes non-breaking spaces).
+     */
+    public static List<String> normalize(String raw) {
+        if (raw == null) {
+            return List.of();
+        }
+        return java.util.Arrays.stream(raw.split(";"))
+                .map(s -> s.replace(' ', ' ').strip())
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    public static boolean isValid(String part) {
+        return ADDRESS_PART.matcher(part).matches();
+    }
+}

--- a/src/main/java/org/vfeeg/eegfaktura/billing/util/EmailAddressUtil.java
+++ b/src/main/java/org/vfeeg/eegfaktura/billing/util/EmailAddressUtil.java
@@ -19,17 +19,18 @@ public final class EmailAddressUtil {
 
     /**
      * Splits a ';'-separated address list, strips outer whitespace per
-     * part and drops empty parts. NBSP (U+00A0, typical Excel/copy-paste
-     * artifact) is mapped to a space first — neither String#trim nor
-     * String#strip treats it as whitespace ({@code Character.isWhitespace}
-     * excludes non-breaking spaces).
+     * part and drops empty parts. The non-breaking spaces U+00A0/
+     * U+202F/U+2007 (typical Excel & copy-paste artifacts) are mapped
+     * to a space first — neither String#trim nor String#strip treats
+     * them as whitespace ({@code Character.isWhitespace} excludes
+     * non-breaking spaces).
      */
     public static List<String> normalize(String raw) {
         if (raw == null) {
             return List.of();
         }
         return java.util.Arrays.stream(raw.split(";"))
-                .map(s -> s.replace(' ', ' ').strip())
+                .map(s -> s.replaceAll("[\u00A0\u202F\u2007]", " ").strip())
                 .filter(s -> !s.isEmpty())
                 .toList();
     }

--- a/src/test/java/org/vfeeg/eegfaktura/billing/util/EmailAddressUtilTest.java
+++ b/src/test/java/org/vfeeg/eegfaktura/billing/util/EmailAddressUtilTest.java
@@ -1,0 +1,31 @@
+package org.vfeeg.eegfaktura.billing.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmailAddressUtilTest {
+
+    @Test
+    void normalizeStripsOuterWhitespacePerPart() {
+        assertEquals(List.of("a@x.at"), EmailAddressUtil.normalize(" a@x.at "));
+        assertEquals(List.of("a@x.at", "b@y.at"), EmailAddressUtil.normalize("a@x.at ; b@y.at"));
+        // NBSP (U+00A0) — String#trim would keep it, strip() removes it
+        assertEquals(List.of("a@x.at"), EmailAddressUtil.normalize(" a@x.at "));
+        assertEquals(List.of(), EmailAddressUtil.normalize("  "));
+        assertEquals(List.of(), EmailAddressUtil.normalize(null));
+    }
+
+    @Test
+    void isValidAppliesSharedRule() {
+        assertTrue(EmailAddressUtil.isValid("a@x.at"));
+        assertTrue(EmailAddressUtil.isValid("A@X.AT"));
+        assertTrue(EmailAddressUtil.isValid("a@eeg.energy")); // modern gTLD, no allowlist
+        assertFalse(EmailAddressUtil.isValid("x"));
+        assertFalse(EmailAddressUtil.isValid("hedwig.schön@x.at")); // non-ASCII local part
+        assertFalse(EmailAddressUtil.isValid("a b@x.at")); // inner whitespace
+        assertFalse(EmailAddressUtil.isValid("a@x")); // missing TLD
+    }
+}


### PR DESCRIPTION
## Was

billing-Teil der suite-weiten **Mailversand-Adress-Härtung** (Konzept `konzept-mailversand-adress-haertung.md`; Prod-Befund: `Illegal address`-Fehler, überwiegend äußerer Whitespace).

- **`EmailAddressUtil`** (neu): gemeinsame Suite-Regel (ASCII-Local-Part, TLD ≥ 2 Buchstaben, keine Allowlist); `normalize` splittet `;`, strippt äußeres Whitespace **inkl. U+00A0/U+202F/U+2007** (Review-Finding: `String#strip` deckt non-breaking spaces NICHT — `Character.isWhitespace` schließt sie aus).
- **`EmailService.sendEmail`** versendet die **normalisierten** Werte (bisher gingen Roh-Strings an den Mail-Parser → `Illegal address`), stellt an die gültigen Teile zu und liefert die verworfenen zurück; kein gültiges `to` = Fehler.
- **Run-Protokoll**: FEHLER-Zeilen nennen jetzt **MitgliedsNr + Name** (null-safe) — eine leere/kaputte Adresse erzeugte bisher ein nicht zuordenbares `"  FEHLER"`. **Wichtig (Review-Finding #1):** verworfene Teil-Empfänger einer **zugestellten** Mail (z. B. ungültiges Office-cc) erscheinen als Warnhinweis auf der OK-Zeile, **nicht** als FEHLER — sonst provoziert das Protokoll manuelle Doppel-Versände (Duplikat-Rechnungen).
- Kein Schema-/Enum-Change, kein Nachversand-Umbau (bewusst ausgeklammert, eigenes Folge-Issue).

## ⚠️ Rollout-Gate

Vor Prod: DB-Scan auf Local-Parts mit RFC-Sonderzeichen (`'`, `!`, `&` …) — billing hat bisher **gar nicht** validiert und solche Adressen zugestellt; die konservative Regel würde sie filtern. Scan-SQL im Konzept-Runbook; bei Treffern Regel suite-weit erweitern (ein Konstanten-Fix je Stack).

## Tests

`mvnw compile` ✅ · `EmailAddressUtilTest` ✅ (inkl. echter NBSP-Bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)