### PR TITLE
docs(changelog): release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.2] – 2026-07-05
+
 ### Fixed
 - Mail send no longer hands raw recipient strings to the mail parser ("Illegal address",
   observed in prod for addresses with leading/trailing whitespace): to/cc are normalized per
@@ -23,6 +25,7 @@ this changelog highlights the changes relevant for overview and operations.
   issuer cc) are reported as a warning on the OK line, NOT as FEHLER — flagging a delivered
   invoice as failed would invite manual re-sends and duplicate invoices.
 - CI: Preview-Deployments (ADR-0007) — Push auf `preview/**` baut+deployt on-demand in die Dev-Zone (sha-pinned, kein `:latest`), Auto-Reset bei Branch-Delete.
+
 
 ## [1.0.1] – 2026-06-30
 


### PR DESCRIPTION
Stampt die [Unreleased]-Einträge als **v1.0.2** (Release-Zug Mailversand-Adress-Härtung; Image-Tag per crane auf den dev-verifizierten Digest gesetzt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)