### PR TITLE
security(docker): JRE-only runtime + non-root user + OCI labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,24 @@ RUN mvn -B -ntp dependency:go-offline -DskipTests
 COPY src ./src
 RUN mvn -B -ntp clean package -DskipTests
 
-FROM eclipse-temurin:21
+# JRE statt JDK (kleineres Image, weniger CVE-Surface).
+FROM eclipse-temurin:21-jre-jammy
+
+LABEL org.opencontainers.image.title="eegfaktura-billing"
+LABEL org.opencontainers.image.description="EEG Faktura Abrechnungs-Service (Rechnungen, Gutschriften, SEPA, Mail-Versand)"
+LABEL org.opencontainers.image.vendor="Verein zur Förderung von Erneuerbaren Energiegemeinschaften"
+LABEL org.opencontainers.image.licenses=AGPL-3.0
+
+# Non-root runtime user (Pod-Security-Admission "restricted" + Defense-in-Depth).
+RUN groupadd -r app --gid 1001 \
+    && useradd -r -g app --uid 1001 -s /sbin/nologin -M app
+
 # Version-Glob: passt zu jedem `eegfaktura-billing-*.jar`, robust gegen pom.xml-Bumps.
 COPY --from=builder /build/target/eegfaktura-billing-*.jar /opt/app/eegfaktura-billing.jar
 WORKDIR /opt/app
+
+# Numerische UID:GID statt Username: kubelet kann runAsNonRoot nur bei
+# numerischer USER-Direktive verifizieren (CreateContainerConfigError sonst).
+USER 1001:1001
+
 ENTRYPOINT ["java","-jar","/opt/app/eegfaktura-billing.jar"]


### PR DESCRIPTION
Three hardening changes to the runtime image stage:

## 1. JRE-only image

`eclipse-temurin:21` → `eclipse-temurin:21-jre-jammy`. JRE image is ~40% smaller and drops the JDK CVE surface. The multi-stage builder already carries the JDK for `mvn package`.

## 2. Non-root runtime user

`groupadd` + `useradd` with numeric UID/GID 1001, then `USER 1001:1001`. Required for Pod-Security-Admission `restricted` profile. Numeric form is necessary because kubelet runAsNonRoot enforcement can't validate a named user (`CreateContainerConfigError` otherwise).

## 3. OCI image labels

Title, description, vendor, licenses for registry/SBOM consumers.

Discovered while diffing gemeinstrom's fork against upstream during Fork-Cutover-Planning (2026-07-12).

🤖 Prepared via Claude Code